### PR TITLE
Getting latest datapoint returns multiple values

### DIFF
--- a/open-nti/open-nti.py
+++ b/open-nti/open-nti.py
@@ -81,7 +81,7 @@ def get_latest_datapoints(**kwargs):
     dbclient.switch_database(db_name)
     results = {}
     if db_schema == 1:
-        query = "select * from /%s\./ GROUP BY * ORDER BY time DESC limit 1 " % (kwargs['host'])
+        query = "select * from /%s\./ ORDER BY time DESC limit 1 " % (kwargs['host'])
     elif db_schema == 2:
         query = "select * from \"%s\" WHERE device = '%s' GROUP BY * ORDER BY time DESC limit 1 " % ('jnpr.collector',kwargs['host'])
     elif db_schema == 3:


### PR DESCRIPTION
In scenarios where any of the base tags for each datapoint (version/hostname/model) changes, the get_latest_datapoints, returns more than one value due a 'GROUP BY *' in the query string,  so the following messages appears

2016-06-20 08:46:03 _open-nti_ ERROR Thread-14 :  ERROR: Latest datapoint query <......> returns more than one match <[datapoint1] ,[ datapoint 2']>

And no values are returned.

This fix remove the GROUP BY * and solves the proble