### PR TITLE
Internal kpi and improve importing error

### DIFF
--- a/docker/telegraf/telegraf.conf
+++ b/docker/telegraf/telegraf.conf
@@ -1,86 +1,142 @@
-# Telegraf configuration
-
+# Telegraf Configuration
+#
 # Telegraf is entirely plugin driven. All metrics are gathered from the
 # declared inputs, and sent to the declared outputs.
-
+#
 # Plugins must be declared in here to be active.
 # To deactivate a plugin, comment out the name and any variables.
-
+#
 # Use 'telegraf -config telegraf.conf -test' to see what metrics a config
 # file would generate.
+#
+# Environment variables can be used anywhere in this config file, simply prepend
+# them with $. For strings the variable must be within quotes (ie, "$STR_VAR"),
+# for numbers and booleans they should be plain (ie, $INT_VAR, $BOOL_VAR)
+
 
 # Global tags can be specified here in key="value" format.
-[tags]
+[global_tags]
   # dc = "us-east-1" # will tag all metrics with dc=us-east-1
   # rack = "1a"
+  ## Environment variables can be used as tags, and throughout the config file
+  # user = "$USER"
+
 
 # Configuration for telegraf agent
 [agent]
-  # Default data collection interval for all inputs
+  ## Default data collection interval for all inputs
   interval = "10s"
-  # Rounds collection interval to 'interval'
-  # ie, if interval="10s" then always collect on :00, :10, :20, etc.
+  ## Rounds collection interval to 'interval'
+  ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
   round_interval = true
 
-  # Telegraf will cache metric_buffer_limit metrics for each output, and will
-  # flush this buffer on a successful write.
+  ## Telegraf will send metrics to outputs in batches of at
+  ## most metric_batch_size metrics.
+  metric_batch_size = 1000
+  ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
+  ## output, and will flush this buffer on a successful write. Oldest metrics
+  ## are dropped first when this buffer fills.
   metric_buffer_limit = 10000
 
-  # Collection jitter is used to jitter the collection by a random amount.
-  # Each plugin will sleep for a random time within jitter before collecting.
-  # This can be used to avoid many plugins querying things like sysfs at the
-  # same time, which can have a measurable effect on the system.
+  ## Collection jitter is used to jitter the collection by a random amount.
+  ## Each plugin will sleep for a random time within jitter before collecting.
+  ## This can be used to avoid many plugins querying things like sysfs at the
+  ## same time, which can have a measurable effect on the system.
   collection_jitter = "0s"
 
-  # Default data flushing interval for all outputs. You should not set this below
-  # interval. Maximum flush_interval will be flush_interval + flush_jitter
+  ## Default flushing interval for all outputs. You shouldn't set this below
+  ## interval. Maximum flush_interval will be flush_interval + flush_jitter
   flush_interval = "10s"
-  # Jitter the flush interval by a random amount. This is primarily to avoid
-  # large write spikes for users running a large number of telegraf instances.
-  # ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+  ## Jitter the flush interval by a random amount. This is primarily to avoid
+  ## large write spikes for users running a large number of telegraf instances.
+  ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
   flush_jitter = "0s"
 
-  # Run telegraf in debug mode
+  ## Run telegraf in debug mode
   debug = false
-  # Run telegraf in quiet mode
+  ## Run telegraf in quiet mode
   quiet = false
-  # Override default hostname, if empty use os.Hostname()
+  ## Override default hostname, if empty use os.Hostname()
   hostname = ""
+  ## If set to true, do no set the "host" tag in the telegraf agent.
+  omit_hostname = false
 
 
 ###############################################################################
-#                                  OUTPUTS                                    #
+#                            OUTPUT PLUGINS                                   #
 ###############################################################################
-
 
 # Configuration for influxdb server to send metrics to
 [[outputs.influxdb]]
-  # The full HTTP or UDP endpoint URL for your InfluxDB instance.
-  # Multiple urls can be specified but it is assumed that they are part of the same
-  # cluster, this means that only ONE of the urls will be written to each interval.
+  ## The full HTTP or UDP endpoint URL for your InfluxDB instance.
+  ## Multiple urls can be specified as part of the same cluster,
+  ## this means that only ONE of the urls will be written to each interval.
   # urls = ["udp://localhost:8089"] # UDP endpoint example
   urls = ["http://localhost:8086"] # required
-  # The target database for metrics (telegraf will create it if not exists)
-  database = "juniper" # required
-  # Precision of writes, valid values are n, u, ms, s, m, and h
-  # note: using second precision greatly helps InfluxDB compression
+  ## The target database for metrics (telegraf will create it if not exists).
+  database = "telegraf" # required
+  ## Precision of writes, valid values are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+  ## note: using "s" precision greatly improves InfluxDB compression.
   precision = "s"
 
-  # Connection timeout (for the connection with InfluxDB), formatted as a string.
-  # If not provided, will default to 0 (no timeout)
-  # timeout = "5s"
+  ## Retention policy to write to.
+  retention_policy = "default"
+  ## Write consistency (clusters only), can be: "any", "one", "quorom", "all"
+  write_consistency = "any"
+
+  ## Write timeout (for the InfluxDB client), formatted as a string.
+  ## If not provided, will default to 5s. 0s means no timeout (not recommended).
+  timeout = "5s"
   # username = "telegraf"
   # password = "metricsmetricsmetricsmetrics"
-  # Set the user agent for HTTP POSTs (can be useful for log differentiation)
+  ## Set the user agent for HTTP POSTs (can be useful for log differentiation)
   # user_agent = "telegraf"
-  # Set UDP payload size, defaults to InfluxDB UDP Client default (512 bytes)
+  ## Set UDP payload size, defaults to InfluxDB UDP Client default (512 bytes)
   # udp_payload = 512
 
+  ## Optional SSL Config
+  # ssl_ca = "/etc/telegraf/ca.pem"
+  # ssl_cert = "/etc/telegraf/cert.pem"
+  # ssl_key = "/etc/telegraf/key.pem"
+  ## Use SSL but skip chain & host verification
+  # insecure_skip_verify = false
+
+
 
 ###############################################################################
-#                                  INPUTS                                     #
+#                            INPUT PLUGINS                                    #
 ###############################################################################
 
+# Read metrics about cpu usage
+[[inputs.cpu]]
+  ## Whether to report per-cpu stats or not
+  percpu = true
+  ## Whether to report total system cpu stats or not
+  totalcpu = true
+  ## Comment this line if you want the raw CPU time metrics
+  fielddrop = ["time_*"]
+
+
+# Read InfluxDB-formatted JSON metrics from one or more HTTP endpoints
+[[inputs.influxdb]]
+  ## Works with InfluxDB debug endpoints out of the box,
+  ## but other services can use this format too.
+  ## See the influxdb plugin's README for more details.
+
+  ## Multiple URLs from which to read InfluxDB-formatted JSON
+  urls = [
+    "http://localhost:8086/debug/vars"
+  ]
+
+
+# Read metrics about memory usage
+[[inputs.mem]]
+  # no configuration
+
+
+# Read metrics about swap memory usage
+[[inputs.swap]]
+  # no configuration
 
 
 ###############################################################################

--- a/open-nti/open-nti.py
+++ b/open-nti/open-nti.py
@@ -297,7 +297,7 @@ def get_metadata_and_add_datapoint(datapoints,**kwargs):
     # Calculating delta values (only applies for numeric values)
     delta = 0
     latest_value = ''
-    if type (value) != str:
+    if (type (value) != str):
 
         points=[]
         if (db_schema == 1):
@@ -478,8 +478,8 @@ def collector(**kwargs):
 #        if ((db_schema == 1) and (not(use_hostname))):
         if (not(use_hostname)):
             latest_datapoints = get_latest_datapoints(host=host)
-            logger.info("Latest Datapoints are:")
-            logger.info(pformat(latest_datapoints))
+            logger.debug("Latest Datapoints are:")
+            logger.debug(pformat(latest_datapoints))
 
         #    kpi_tags = get_host_base_tags(host=host)
         # Check host tag to identify what kind of connections will be used (ej junos / others  / etc)
@@ -559,8 +559,8 @@ def collector(**kwargs):
 #                            logger.info("Latest Datapoints are:")
 #                            logger.info(pformat(latest_datapoints))
                         latest_datapoints = get_latest_datapoints(host=host)
-                        logger.info("Latest Datapoints are:")
-                        logger.info(pformat(latest_datapoints))
+                        logger.debug("Latest Datapoints are:")
+                        logger.debug(pformat(latest_datapoints))
                     else:
                         logger.info('[%s]: Host will be referenced as : %s', host, host)
 
@@ -588,14 +588,50 @@ def collector(**kwargs):
 
                 timestamp_tracking['collector_cli_ends'] = int(datetime.today().strftime('%s'))
                 logger.info('[%s]: timestamp_tracking - CLI collection %s', host, timestamp_tracking['collector_cli_ends']-timestamp_tracking['collector_cli_start'])
+                timestamp_tracking['collector_ends'] = int(datetime.today().strftime('%s'))
+
+                # Add open-nti internal kpi 
+                collection_time = timestamp_tracking['collector_ends']-timestamp_tracking['collector_start']
+                #kpi_tags['device']=host
+                kpi_tags['stats']="collection-time"
+                match={}
+                match["variable-name"]="open-nti-stats"
+                value_tmp =collection_time
+                # We'll add a dummy kpi in oder to have at least one fixed kpi with version/platform data.
+                get_metadata_and_add_datapoint(datapoints=datapoints,match=match,value_tmp=value_tmp,latest_datapoints=latest_datapoints,host=host,kpi_tags=kpi_tags)
+
+                #kpi_tags['device']=host
+                kpi_tags['stats']="collection-successful"
+                match={}
+                match["variable-name"]="open-nti-stats"
+                value_tmp = 1
+                # We'll add a dummy kpi in oder to have at least one fixed kpi with version/platform data.
+                get_metadata_and_add_datapoint(datapoints=datapoints,match=match,value_tmp=value_tmp,latest_datapoints=latest_datapoints,host=host,kpi_tags=kpi_tags)
+
+
 
                 if datapoints:   # Only insert datapoints if there is any :)
                     insert_datapoints(datapoints)
 
-                timestamp_tracking['collector_ends'] = int(datetime.today().strftime('%s'))
-                logger.info('[%s]: timestamp_tracking - total collection %s', host, timestamp_tracking['collector_ends']-timestamp_tracking['collector_start'])
+                
+                logger.info('[%s]: timestamp_tracking - total collection %s', host, collection_time)
             else:
                 logger.error('[%s]: Skipping host due connectivity issue', host)
+
+                datapoints = []
+                latest_datapoints = get_latest_datapoints(host=host)
+                # By default execute show version in order to get version and platform as default tags for all kpi related to this host
+                kpi_tags['device']=host
+                kpi_tags['stats']="collection-failure"
+                match={}
+                match["variable-name"]="open-nti-stats"
+                value_tmp = 1
+                # We'll add a dummy kpi in oder to have at least one fixed kpi with version/platform data.
+                get_metadata_and_add_datapoint(datapoints=datapoints,match=match,value_tmp=value_tmp,latest_datapoints=latest_datapoints,host=host,kpi_tags=kpi_tags)
+
+                if datapoints:   # Only insert datapoints if there is any :)
+                    insert_datapoints(datapoints)
+
 
 
 ################################################################################################
@@ -637,8 +673,13 @@ if dynamic_args['test']:
 default_variables_yaml_file = BASE_DIR_INPUT + "open-nti.variables.yaml"
 default_variables = {}
 
-with open(default_variables_yaml_file) as f:
-    default_variables = yaml.load(f)
+try:
+    with open(default_variables_yaml_file) as f:
+        default_variables = yaml.load(f)
+except Exception, e:
+    logger.info('Error importing default variables file": %s', default_variables_yaml_file)
+    logging.exception(e)
+    sys.exit(0)
 
 db_schema = default_variables['db_schema']
 db_server = default_variables['db_server']
@@ -695,16 +736,26 @@ if dynamic_args['console']:
 credentials_yaml_file = BASE_DIR_INPUT + default_variables['credentials_file']
 credentials = {}
 logger.debug('Importing credentials file: %s ',credentials_yaml_file)
-with open(credentials_yaml_file) as f:
-    credentials = yaml.load(f)
-
+try:
+    with open(credentials_yaml_file) as f:
+        credentials = yaml.load(f)
+except Exception, e:
+    logger.error('Error importing credentials file: %s', credentials_yaml_file)
+ #   logging.exception(e)
+    sys.exit(0)  
 #  LOAD all hosts with their tags in a dic
 
 hosts_yaml_file = BASE_DIR_INPUT + default_variables['hosts_file']
 hosts = {}
 logger.debug('Importing host file: %s ',hosts_yaml_file)
-with open(hosts_yaml_file) as f:
-    hosts = yaml.load(f)
+try:
+    with open(hosts_yaml_file) as f:
+        hosts = yaml.load(f)
+except Exception, e:
+    logger.error('Error importing host file: %s', hosts_yaml_file)
+    #logging.exception(e)
+    sys.exit(0)        
+
 
 #  LOAD all commands with their tags in a dict
 
@@ -712,8 +763,13 @@ commands_yaml_file = BASE_DIR_INPUT + default_variables['commands_file']
 commands = []
 logger.debug('Importing commands file: %s ',commands_yaml_file)
 with open(commands_yaml_file) as f:
-    for document in yaml.load_all(f):
-        commands.append(document)
+    try:
+        for document in yaml.load_all(f):
+            commands.append(document)
+    except Exception, e:
+        logger.error('Error importing commands file: %s', commands_yaml_file)
+#        logging.exception(e)
+        sys.exit(0)        
 
 general_commands = commands[0]
 
@@ -723,15 +779,25 @@ junos_parsers = []
 junos_parsers_yaml_files = os.listdir(BASE_DIR + "/" + default_variables['junos_parsers_dir'])
 logger.debug('Importing junos parsers file: %s ',junos_parsers_yaml_files)
 for junos_parsers_yaml_file in junos_parsers_yaml_files:
-    with open(BASE_DIR + "/" + default_variables['junos_parsers_dir'] + "/"  + junos_parsers_yaml_file) as f:
-        junos_parsers.append(yaml.load(f))
+    try:
+        with open(BASE_DIR + "/" + default_variables['junos_parsers_dir'] + "/"  + junos_parsers_yaml_file) as f:
+            junos_parsers.append(yaml.load(f))
+    except Exception, e:
+        logger.error('Error importing junos parser: %s', junos_parsers_yaml_file)
+ #       logging.exception(e)
+        pass
 
 pfe_parsers = []
 pfe_parsers_yaml_files = os.listdir(BASE_DIR + "/" + default_variables['pfe_parsers_dir'])
 logger.debug('Importing pfe parsers file: %s ',pfe_parsers_yaml_files)
 for pfe_parsers_yaml_file in pfe_parsers_yaml_files:
-    with open(BASE_DIR + "/" + default_variables['pfe_parsers_dir'] + "/" + pfe_parsers_yaml_file) as f:
-        pfe_parsers.append(yaml.load(f))
+    try:
+        with open(BASE_DIR + "/" + default_variables['pfe_parsers_dir'] + "/" + pfe_parsers_yaml_file) as f:
+            pfe_parsers.append(yaml.load(f))
+    except Exception, e:
+        logger.error('Error importing pfe parser: %s', pfe_parsers_yaml_file)
+ #       logging.exception(e)
+        pass
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
Adding open-nti internal kpi (keep track of how much time it takes gather datapoints for each target)

Adding though telegraph influxdb kpi and container (cpu/mem/storage) kpi

Improve error handling when importing configuration files.