### PR TITLE
Debugging jti

### DIFF
--- a/plugins/input-jti/fluent.conf
+++ b/plugins/input-jti/fluent.conf
@@ -31,6 +31,22 @@
     bind 0.0.0.0
 </source>
 
+
+#################
+## Filters    ###
+#################
+
+#  Adding a filter example for future references
+#
+#  <filter jnpr.**>
+#    @type record_transformer
+#    enable_ruby
+#    <record>
+#      timestamp_utc ${Time.now.utc.strftime('%Y-%m-%dT%H:%M:%S.%9NZ')}
+#    </record>
+#  </filter>
+
+
 #################
 ## Output     ###
 #################
@@ -41,6 +57,7 @@
     <store>
         @type stdout
         @id stdout_output
+        localtime
     </store>
 {% endif %}
 {% if OUTPUT_INFLUXDB == 'true' %}

--- a/plugins/input-jti/plugins/out_influxdb.rb
+++ b/plugins/input-jti/plugins/out_influxdb.rb
@@ -55,7 +55,11 @@ class Fluent::InfluxdbOutput < Fluent::BufferedOutput
         points = []
         chunk.msgpack_each do |tag, time, record|
             point = {}
-            point[:timestamp] = record.delete('time') || time
+            # Data inserted into influxdb should not contains timestamp, so influx insert it own timestamp
+            # and timezone (UTC)
+            # point[:timestamp] = record.delete('time') || time
+            point[:timestamp] = record.delete('time') 
+            
             point[:series] = tag
 
             if ( tag_keys.empty? && value_keys.empty? )


### PR DESCRIPTION
Remove timestamp information received sampled, so database insert its own timestamp (some problems/confusion has arised when different timezones are being used, because influxdb only works in UTC)