### PR TITLE
auto restart container

### DIFF
--- a/docker-compose/opennti_persistent.yml
+++ b/docker-compose/opennti_persistent.yml
@@ -2,6 +2,7 @@
 input-jti:
   image: $INPUT_JTI_IMAGE_NAME:$IMAGE_TAG
   container_name: $INPUT_JTI_CONTAINER_NAME
+  restart: always
   environment:
    - "INFLUXDB_ADDR=opennti"
    - "OUTPUT_INFLUXDB=true"
@@ -17,6 +18,7 @@ input-jti:
 input-syslog:
   image: $INPUT_SYSLOG_IMAGE_NAME:$IMAGE_TAG
   container_name: $INPUT_SYSLOG_CONTAINER_NAME
+  restart: always
   environment:
    - "INFLUXDB_ADDR=opennti"
    - "OUTPUT_INFLUXDB=true"
@@ -47,6 +49,7 @@ input-internal:
 opennti:
   image: $MAIN_IMAGE_NAME:$IMAGE_TAG
   container_name: $MAIN_CONTAINER_NAME
+  restart: always
   volumes:
    - ../$LOCAL_DIR_DASHBOARD:/src/dashboards
    - ../$LOCAL_DIR_DATA:/opt/open-nti/data


### PR DESCRIPTION
The following change in docker compose file is required to automatically restart the containers. 

We run into the situation that docker was restarted during upgrade and container was stopped but not restarted (similar after reboot). 