### PR TITLE
Fix misspelling of streaming (was steaming)

### DIFF
--- a/dashboards/data_streaming_collector.yaml
+++ b/dashboards/data_streaming_collector.yaml
@@ -1,5 +1,5 @@
 
-title: Data Steaming Collector Dashboard
+title: Data Streaming Collector Dashboard
 template: "dashboard_base.j2"
 
 tags:

--- a/dashboards/data_streaming_collector_dashboard.json
+++ b/dashboards/data_streaming_collector_dashboard.json
@@ -1,7 +1,7 @@
 {
   "id": null,
-  "title": "Data Steaming Collector Dashboard",
-  "originalTitle": "Data Steaming Collector Dashboard",
+  "title": "Data Streaming Collector Dashboard",
+  "originalTitle": "Data Streaming Collector Dashboard",
 "tags": [
     "juniper","jti","opennti","streaming"
   ],

--- a/dashboards/qfx_udp_oc_streaming.yaml
+++ b/dashboards/qfx_udp_oc_streaming.yaml
@@ -1,5 +1,5 @@
 
-title: Data Steaming Collector ALPHA
+title: Data Streaming Collector ALPHA
 template: "dashboard_base.j2"
 
 tags:

--- a/docs/dashboard.rst
+++ b/docs/dashboard.rst
@@ -23,7 +23,7 @@ To generate a dashboard you need to create a yaml file that indicate: the title,
 
 .. code-block:: yaml
 
-  title: Data Steaming Collector ALPHA
+  title: Data Streaming Collector ALPHA
   template: "dashboard_base.j2"
 
   tags:


### PR DESCRIPTION
Streaming was misspelled as "Steaming" in multiple files; this was most prominent in one of the dashboard titles.  This PR fixes those misspellings and updates one filename with a misspelling.