### PR TITLE
Create junos parser for 'show ddos-protection' command

### DIFF
--- a/data/junos_parsers/show-ddos-protection.parser.yaml
+++ b/data/junos_parsers/show-ddos-protection.parser.yaml
@@ -1,0 +1,23 @@
+parser:
+    regex-command: show\s+ddos-protection\s+protocols(?:\s+|\s+\S*\s+)statistics\s+brief\s+\|\s+display\s+xml
+    matches:
+    -
+        type: multi-value
+        method: xpath
+        xpath: //ddos-system-statistics
+        loop:
+            group: ./group-name
+            type: ./packet-type
+            sub-matches:
+            -
+                xpath: ./packet-received
+                variable-name:  $host.ddos-protection.$group.$type.packets-received
+            -
+                xpath: ./packet-dropped
+                variable-name:  $host.ddos-protection.$group.$type.packets-dropped
+            -
+                xpath: ./packet-arrival-rate
+                variable-name:  $host.ddos-protection.$group.$type.packet-rate
+            -
+                xpath: ./policer-violation-count
+                variable-name:  $host.ddos-protection.$group.$type.policer-violation-count


### PR DESCRIPTION
This is a junos parser for 
`show ddos-protection protocols [optional_protocol] statistics brief | display xml`

The parser creates a separate measurement for each protocol group, protocol type, and KPI combination and pulls stats for received packets, dropped packets, packet rate, and violation count.

I recommend you include a statement for each protocol you want to collect data for in your commands.yaml file.  You can omit the optional_protocol and the command will pull stats for all protocols which will likely result in 800+ separate measurements.

Example data set:
```
> show ddos-protection protocols sample statistics brief
Packet types: 7, Received traffic: 0, Currently violated: 0

Protocol    Packet      Received        Dropped        Rate     Violation State
group       type        (packets)       (packets)      (pps)    counts
sample      aggregate   0               0              0        0         ok
sample      syslog      0               0              0        0         ok
sample      host        0               0              0        0         ok
sample      pfe         0               0              0        0         ok
sample      tap         0               0              0        0         ok
sample      sflow       0               0              0        0         ok
```