### PR TITLE
Adding Kafka compression_codec override

### DIFF
--- a/plugins/input-jti/Dockerfile
+++ b/plugins/input-jti/Dockerfile
@@ -62,6 +62,7 @@ ENV OUTPUT_KAFKA=false \
     KAFKA_ADDR=localhost \
     KAFKA_PORT=9092 \
     KAFKA_DATA_TYPE=json \
+    KAFKA_COMPRESSION_CODEC=none \
     KAFKA_TOPIC=jnpr.jvision
 
 CMD /home/fluent/fluentd-alpine.start.sh

--- a/plugins/input-jti/fluent.conf
+++ b/plugins/input-jti/fluent.conf
@@ -101,7 +101,7 @@
       # max_send_retries    (integer)    :default => 3
       # required_acks       (integer)    :default => 0
       # ack_timeout_ms      (integer)    :default => 1500
-      # compression_codec   (none|gzip|snappy) :default => none
+      compression_codec     {{ KAFKA_COMPRESSION_CODEC }} # (none|gzip|snappy) :default => none
     </store>
 {% endif %}
 </match>


### PR DESCRIPTION
This will help reducing disk space usage by compression the records. We've seen 20x compression ratios on logs before. Gzip should probably be enabled by default, but I left it to `none`. 