### PR TITLE
Fix default dashboards internal and lw4o6

### DIFF
--- a/dashboards/lw4o6.json
+++ b/dashboards/lw4o6.json
@@ -1,38 +1,8 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_INFLUXDB",
-      "label": "influxdb",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "influxdb",
-      "pluginName": "InfluxDB"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "4.1.2"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "influxdb",
-      "name": "InfluxDB",
-      "version": "1.0.0"
-    }
-  ],
   "annotations": {
     "list": [
       {
-        "datasource": "${DS_INFLUXDB}",
+        "datasource": "influxdb",
         "enable": true,
         "iconColor": "#C0C6BE",
         "iconSize": 13,
@@ -61,7 +31,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "description": "Overall pps of IPv6 and IPv4 processed packets",
           "fill": 1,
           "id": 101,
@@ -302,7 +272,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "description": "Overall pps of IPv6 and IPv4 processed packets",
           "fill": 1,
           "id": 103,
@@ -555,7 +525,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "fill": 1,
           "id": 104,
           "legend": {
@@ -691,7 +661,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "fill": 1,
           "id": 105,
           "legend": {
@@ -843,7 +813,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -947,7 +917,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -1063,7 +1033,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -1170,7 +1140,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -1276,7 +1246,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -1382,7 +1352,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -1500,7 +1470,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -1605,7 +1575,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -1709,7 +1679,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -1813,7 +1783,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -1917,7 +1887,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -2021,7 +1991,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -2137,7 +2107,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -2241,7 +2211,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -2345,7 +2315,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -2449,7 +2419,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -2553,7 +2523,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -2657,7 +2627,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -2761,7 +2731,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -2865,7 +2835,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -2969,7 +2939,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -3085,7 +3055,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -3190,7 +3160,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -3294,7 +3264,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -3398,7 +3368,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -3502,7 +3472,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -3606,7 +3576,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -3722,7 +3692,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -3827,7 +3797,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -3932,7 +3902,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -4037,7 +4007,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -4142,7 +4112,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -4247,7 +4217,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -4352,7 +4322,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -4457,7 +4427,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -4562,7 +4532,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -4667,7 +4637,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -4772,7 +4742,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -4879,7 +4849,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -4984,7 +4954,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -5101,7 +5071,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -5206,7 +5176,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -5311,7 +5281,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -5428,7 +5398,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -5527,7 +5497,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -5642,7 +5612,7 @@
         "allFormat": "glob",
         "allValue": "",
         "current": {},
-        "datasource": "${DS_INFLUXDB}",
+        "datasource": "influxdb",
         "hide": 0,
         "includeAll": true,
         "label": null,

--- a/dashboards/open-nti_internal.json
+++ b/dashboards/open-nti_internal.json
@@ -1,56 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_DOCKER_INTERNAL",
-      "label": "docker_internal",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "influxdb",
-      "pluginName": "InfluxDB"
-    },
-    {
-      "name": "DS_INFLUXDB_INTERNAL",
-      "label": "influxdb_internal",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "influxdb",
-      "pluginName": "InfluxDB"
-    },
-    {
-      "name": "DS_INFLUXDB",
-      "label": "influxdb",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "influxdb",
-      "pluginName": "InfluxDB"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "4.1.2"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "influxdb",
-      "name": "InfluxDB",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": []
   },
@@ -69,7 +17,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_DOCKER_INTERNAL}",
+          "datasource": "docker_internal",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -195,7 +143,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_DOCKER_INTERNAL}",
+          "datasource": "docker_internal",
           "editable": true,
           "error": false,
           "format": "none",
@@ -309,7 +257,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_DOCKER_INTERNAL}",
+          "datasource": "docker_internal",
           "editable": true,
           "error": false,
           "format": "none",
@@ -423,7 +371,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(245, 54, 54, 0.9)"
           ],
-          "datasource": "${DS_DOCKER_INTERNAL}",
+          "datasource": "docker_internal",
           "editable": true,
           "error": false,
           "format": "percent",
@@ -537,7 +485,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_DOCKER_INTERNAL}",
+          "datasource": "docker_internal",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -659,7 +607,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_DOCKER_INTERNAL}",
+          "datasource": "docker_internal",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -868,7 +816,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_DOCKER_INTERNAL}",
+          "datasource": "docker_internal",
           "editable": true,
           "error": false,
           "fill": 2,
@@ -989,7 +937,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_DOCKER_INTERNAL}",
+          "datasource": "docker_internal",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -1219,7 +1167,7 @@
           "targets": [
             {
               "alias": "Queries",
-              "datasource": "${DS_INFLUXDB_INTERNAL}",
+              "datasource": "influxdb_internal",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -1326,7 +1274,7 @@
           "targets": [
             {
               "alias": "Server Errors",
-              "datasource": "${DS_INFLUXDB_INTERNAL}",
+              "datasource": "influxdb_internal",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -1365,7 +1313,7 @@
             },
             {
               "alias": "Client Errors",
-              "datasource": "${DS_INFLUXDB_INTERNAL}",
+              "datasource": "influxdb_internal",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -1472,7 +1420,7 @@
           "targets": [
             {
               "alias": "Write Fail",
-              "datasource": "${DS_INFLUXDB_INTERNAL}",
+              "datasource": "influxdb_internal",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -1511,7 +1459,7 @@
             },
             {
               "alias": "Write OK",
-              "datasource": "${DS_INFLUXDB_INTERNAL}",
+              "datasource": "influxdb_internal",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -1618,7 +1566,7 @@
           "targets": [
             {
               "alias": "sys",
-              "datasource": "${DS_INFLUXDB_INTERNAL}",
+              "datasource": "influxdb_internal",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -1725,7 +1673,7 @@
           "targets": [
             {
               "alias": "$tag_database",
-              "datasource": "${DS_INFLUXDB_INTERNAL}",
+              "datasource": "influxdb_internal",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -1833,7 +1781,7 @@
           "targets": [
             {
               "alias": "$tag_database",
-              "datasource": "${DS_INFLUXDB_INTERNAL}",
+              "datasource": "influxdb_internal",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -1966,7 +1914,7 @@
           "targets": [
             {
               "alias": "",
-              "datasource": "${DS_INFLUXDB_INTERNAL}",
+              "datasource": "influxdb_internal",
               "dsType": "influxdb",
               "groupBy": [
                 {
@@ -2032,7 +1980,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "fill": 0,
           "id": 25,
           "legend": {
@@ -2144,7 +2092,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "influxdb",
           "fill": 0,
           "id": 26,
           "legend": {
@@ -2356,7 +2304,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_DOCKER_INTERNAL}",
+        "datasource": "docker_internal",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -2376,7 +2324,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_DOCKER_INTERNAL}",
+        "datasource": "docker_internal",
         "hide": 0,
         "includeAll": false,
         "label": null,


### PR DESCRIPTION
The dashboards "OpenNTI Internal" and "Lightweight 4 over 6" did not load properly with a clean install.  The dashboard JSON files located in open-nti/dashboards were the result of a Grafana export and can't be loaded directly (one could import the JSON files into Grafana).

I updated the JSON files and the two dashboards should load properly in a clean install.