### PR TITLE
Restore Kafka output functionality

### DIFF
--- a/plugins/input-jti/Dockerfile
+++ b/plugins/input-jti/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v0.12.41
+FROM fluent/fluentd:v0.12.42
 MAINTAINER Damien Garros <dgarros@gmail.com>
 
 ENV FLUENTD_JUNIPER_VERSION 0.3.0
@@ -27,9 +27,10 @@ RUN apk --no-cache --update add \
               influxdb \
               statsd-ruby \
               dogstatsd-ruby \
-              yajl ltsv zookeeper \
+              ltsv zookeeper \
               bigdecimal && \
-    gem install ruby-kafka -v 0.3.17 && \
+    gem install yajl-ruby -v 1.3.1 && \
+    gem install ruby-kafka -v 0.5.3 && \
     gem install --prerelease protobuf && \
     gem install --no-ri --no-rdoc \
                 fluent-plugin-juniper-telemetry -v ${FLUENTD_JUNIPER_VERSION} &&\


### PR DESCRIPTION
Kafka has been broken lately. I've updated/changed a few dependencies in the Dockerfile to restore. As a result, this will make it non-functional for older Kafka brokers (0.9 and lower). 
The current spotify/kafka docker image is running 0.10.

There is still older ruby-kafka and yajl used in the input-syslog which I didn't change as I didn't use and I won't test. Looks like this one wasn't updated for a while since the fluentd image is much older.