### PR TITLE
Upgrade to stable components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.22
+FROM phusion/baseimage:0.10.1
 MAINTAINER Damien Garros <dgarros@gmail.com>
 
 RUN     apt-get -y update && \
@@ -17,9 +17,9 @@ RUN     rm -f /etc/service/sshd/down
 RUN     /usr/sbin/enable_insecure_key
 
 # Latest version
-ENV GRAFANA_VERSION 5.0.3
-ENV INFLUXDB_VERSION 1.5.1
-ENV TELEGRAF_VERSION 1.5.3-1
+ENV GRAFANA_VERSION 5.2.0
+ENV INFLUXDB_VERSION 1.5.4
+ENV TELEGRAF_VERSION 1.7.0-1
 
 RUN     apt-get -y update && \
         apt-get -y install \
@@ -62,10 +62,11 @@ RUN     mkdir /src
 ########################
 ### Install Grafana
 ########################
-RUN     mkdir /src/grafana                                                                                    &&\
-        mkdir /opt/grafana                                                                                    &&\
-        wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${GRAFANA_VERSION}.linux-x64.tar.gz -O /src/grafana.tar.gz &&\
-        tar -xzf /src/grafana.tar.gz -C /opt/grafana --strip-components=1                                     &&\
+
+RUN     mkdir /src/grafana && \
+        mkdir /opt/grafana && \
+        wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${GRAFANA_VERSION}.linux-amd64.tar.gz -O /src/grafana.tar.gz && \
+        tar -xzf /src/grafana.tar.gz -C /opt/grafana --strip-components=1 && \
         rm /src/grafana.tar.gz
 
 RUN     /opt/grafana/bin/grafana-cli plugins install grafana-piechart-panel

--- a/dashboards/open-nti-snmp.json
+++ b/dashboards/open-nti-snmp.json
@@ -46,7 +46,7 @@
               "groupBy": [
                 {
                   "params": [
-                    "1m"
+                    "5m"
                   ],
                   "type": "time"
                 },
@@ -71,7 +71,7 @@
               ],
               "measurement": "interface_statistics",
               "policy": "default",
-              "query": "SELECT derivative(mean(\"ifHCInOctets\"), 1m) FROM \"interface_statistics\" WHERE \"hostname\" =~ /^$host_regex$/ AND \"ifName\" =~ /^$ifName$/ AND $timeFilter GROUP BY time(1m), \"hostname\", \"ifName\" fill(null)",
+              "query": "SELECT derivative(mean(\"ifHCInOctets\"), 5m) FROM \"interface_statistics\" WHERE \"hostname\" =~ /^$host_regex$/ AND \"ifName\" =~ /^$ifName$/ AND $timeFilter GROUP BY time(5m), \"hostname\", \"ifName\" fill(null)",
               "rawQuery": false,
               "refId": "A",
               "resultFormat": "time_series",
@@ -89,7 +89,7 @@
                   },
                   {
                     "params": [
-                      "1m"
+                      "5m"
                     ],
                     "type": "derivative"
                   },
@@ -119,7 +119,7 @@
                   },
                   {
                     "params": [
-                      "1m"
+                      "5m"
                     ],
                     "type": "derivative"
                   },
@@ -220,7 +220,7 @@
               "groupBy": [
                 {
                   "params": [
-                    "1m"
+                    "5m"
                   ],
                   "type": "time"
                 },
@@ -245,7 +245,7 @@
               ],
               "measurement": "interface_statistics",
               "policy": "default",
-              "query": "SELECT derivative(mean(\"ifHCInMulticastPkts\"), 1m) FROM \"interface_statistics\" WHERE \"hostname\" =~ /^$host_regex$/ AND \"ifName\" =~ /^$ifName$/ AND $timeFilter GROUP BY time(1m), \"hostname\", \"ifName\" fill(null)",
+              "query": "SELECT derivative(mean(\"ifHCInMulticastPkts\"), 5m) FROM \"interface_statistics\" WHERE \"hostname\" =~ /^$host_regex$/ AND \"ifName\" =~ /^$ifName$/ AND $timeFilter GROUP BY time(5m), \"hostname\", \"ifName\" fill(null)",
               "rawQuery": false,
               "refId": "A",
               "resultFormat": "time_series",
@@ -263,7 +263,7 @@
                   },
                   {
                     "params": [
-                      "1m"
+                      "5m"
                     ],
                     "type": "derivative"
                   },
@@ -293,7 +293,7 @@
                   },
                   {
                     "params": [
-                      "1m"
+                      "5m"
                     ],
                     "type": "derivative"
                   },
@@ -394,7 +394,7 @@
               "groupBy": [
                 {
                   "params": [
-                    "1m"
+                    "5m"
                   ],
                   "type": "time"
                 },
@@ -419,7 +419,7 @@
               ],
               "measurement": "interface_statistics",
               "policy": "default",
-              "query": "SELECT derivative(mean(\"ifHCInBroadcastPkts\"), 1m), derivative(mean(\"ifHCOutBroadcastPkts\"), 1m) FROM \"interface_statistics\" WHERE \"hostname\" =~ /^$host_regex$/ AND \"ifName\" =~ /^$ifName$/ AND $timeFilter GROUP BY time(1m), \"hostname\", \"ifName\" fill(null)",
+              "query": "SELECT derivative(mean(\"ifHCInBroadcastPkts\"), 5m), derivative(mean(\"ifHCOutBroadcastPkts\"), 5m) FROM \"interface_statistics\" WHERE \"hostname\" =~ /^$host_regex$/ AND \"ifName\" =~ /^$ifName$/ AND $timeFilter GROUP BY time(5m), \"hostname\", \"ifName\" fill(null)",
               "rawQuery": false,
               "refId": "A",
               "resultFormat": "time_series",
@@ -437,7 +437,7 @@
                   },
                   {
                     "params": [
-                      "1m"
+                      "5m"
                     ],
                     "type": "derivative"
                   },
@@ -467,7 +467,7 @@
                   },
                   {
                     "params": [
-                      "1m"
+                      "5m"
                     ],
                     "type": "derivative"
                   },
@@ -568,7 +568,7 @@
               "groupBy": [
                 {
                   "params": [
-                    "1m"
+                    "5m"
                   ],
                   "type": "time"
                 },
@@ -611,7 +611,7 @@
                   },
                   {
                     "params": [
-                      "1m"
+                      "5m"
                     ],
                     "type": "derivative"
                   },
@@ -641,7 +641,7 @@
                   },
                   {
                     "params": [
-                      "1m"
+                      "5m"
                     ],
                     "type": "derivative"
                   },

--- a/docker/fluentd/fluent.conf
+++ b/docker/fluentd/fluent.conf
@@ -1,6 +1,3 @@
-# In v1 configuration, type and id are @ prefix parameters.
-# @type and @id are recommended. type and id are still available for backward compatibility
-
 ## built-in TCP input
 ## $ echo <json> | fluent-cat <tag>
 
@@ -52,7 +49,7 @@
 ########## Syslog for Events ################
 
 <source>
-    type syslog
+    @type syslog
     format newsyslog
     port 6000
     bind 0.0.0.0
@@ -96,13 +93,13 @@
 </match>
 
 <match jnpr.**>
-    type copy
+    @type copy
     # <store>
     #     @type stdout
     #     @id stdout_output
     # </store>
     <store>
-        type influxdb
+        @type influxdb
         host localhost
         port 8086
         dbname juniper
@@ -121,13 +118,13 @@
 </match>
 
 <match jnpr_statsd.**>
-    type copy
+    @type copy
     # <store>
     #     @type stdout
     #     @id stdout_output
     # </store>
     <store>
-        type statsd
+        @type statsd
         host 127.0.0.1
         port 8125
     </store>
@@ -135,25 +132,29 @@
 
 ## Rewrite syslog tag to remove severity and facility
 <match jnpr_events.**>
-  type copy
+  @type copy
   # <store>
   #     @type stdout
   #     @id stdout_output
   # </store>
   <store>
       @type rewrite_tag_filter
-      rewriterule1 message .*  events
+      <rule>
+        key message
+        pattern /.*/
+        tag events
+      </rule>
   </store>
 </match>
 
 <match events.**>
-    type copy
+    @type copy
     # <store>
     #     @type stdout
     #     @id stdout_output
     # </store>
     <store>
-        type influxdb
+        @type influxdb
         host localhost
         port 8086
         dbname juniper

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,6 +1,7 @@
 daemon off;
 user www-data;
 worker_processes 1;
+#pcre_jit on;
 pid /var/run/nginx.pid;
 
 events {
@@ -8,68 +9,63 @@ events {
 }
 
 http {
-  sendfile on;
-  tcp_nopush on;
-  tcp_nodelay on;
-  keepalive_timeout 65;
-  types_hash_max_size 2048;
-  server_tokens off;
-
-  server_names_hash_bucket_size 32;
-
-  include /etc/nginx/mime.types;
   default_type application/octet-stream;
+  include /etc/nginx/mime.types;
 
   access_log off;
   error_log /var/log/nginx_error.log;
 
+  server_tokens off;
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  server_names_hash_bucket_size 32;
+  types_hash_max_size 2048;
+
   gzip on;
+  gzip_vary on;
   gzip_disable "msie6";
+  gzip_buffers 4 32k;
+  gzip_min_length 1024;
+  gzip_types text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript a
+pplication/json application/xml application/rss+xml application/atom+xml font/truetype font/opentype application/vnd.ms-fonto
+bject image/svg+xml;
+
+  large_client_header_buffers 4 256k;
+  client_max_body_size       10m;
+  client_body_buffer_size    128k;
 
   server {
     listen 80 default_server;
     server_name _;
+
+    proxy_connect_timeout      90;
+    proxy_send_timeout         90;
+    proxy_read_timeout         90;
+
+    proxy_buffer_size          4k;
+    proxy_buffers              4 32k;
+    proxy_busy_buffers_size    64k;
+    proxy_temp_file_write_size 64k;
+
     location / {
-        proxy_pass                 http://127.0.0.1:3000/;
-        proxy_set_header           X-Real-IP   $remote_addr;
-        proxy_set_header           X-Forwarded-For  $proxy_add_x_forwarded_for;
-        proxy_set_header           X-Forwarded-Proto  $scheme;
-        proxy_set_header           X-Forwarded-Server  $host;
-        proxy_set_header           X-Forwarded-Host  $host;
-        proxy_set_header           Host  $host;
-
-        client_max_body_size       10m;
-        client_body_buffer_size    128k;
-
-        proxy_connect_timeout      90;
-        proxy_send_timeout         90;
-        proxy_read_timeout         90;
-
-        proxy_buffer_size          4k;
-        proxy_buffers              4 32k;
-        proxy_busy_buffers_size    64k;
-        proxy_temp_file_write_size 64k;
+        proxy_pass        http://127.0.0.1:3000/;
+        proxy_set_header  Host                $host;
+        proxy_set_header  X-Real-IP           $remote_addr;
+        proxy_set_header  X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header  X-Forwarded-Proto   $scheme;
+        proxy_set_header  X-Forwarded-Server  $host;
+        proxy_set_header  X-Forwarded-Host    $host;
     }
     location /graphite/ {
-        proxy_pass                 http://127.0.0.1:8000/;
-        proxy_set_header           X-Real-IP   $remote_addr;
-        proxy_set_header           X-Forwarded-For  $proxy_add_x_forwarded_for;
-        proxy_set_header           X-Forwarded-Proto  $scheme;
-        proxy_set_header           X-Forwarded-Server  $host;
-        proxy_set_header           X-Forwarded-Host  $host;
-        proxy_set_header           Host  $host;
-
-        client_max_body_size       10m;
-        client_body_buffer_size    128k;
-
-        proxy_connect_timeout      90;
-        proxy_send_timeout         90;
-        proxy_read_timeout         90;
-
-        proxy_buffer_size          4k;
-        proxy_buffers              4 32k;
-        proxy_busy_buffers_size    64k;
-        proxy_temp_file_write_size 64k;
+        proxy_pass        http://127.0.0.1:8000/;
+        proxy_set_header  Host                $host;
+        proxy_set_header  X-Real-IP           $remote_addr;
+        proxy_set_header  X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header  X-Forwarded-Proto   $scheme;
+        proxy_set_header  X-Forwarded-Server  $host;
+        proxy_set_header  X-Forwarded-Host    $host;
 
         add_header Access-Control-Allow-Origin "*";
         add_header Access-Control-Allow-Methods "GET, OPTIONS";
@@ -83,26 +79,23 @@ http {
 
     open_log_file_cache max=1000 inactive=20s min_uses=2 valid=1m;
 
+    proxy_connect_timeout      90;
+    proxy_send_timeout         90;
+    proxy_read_timeout         90;
+
+    proxy_buffer_size          4k;
+    proxy_buffers              4 32k;
+    proxy_busy_buffers_size    64k;
+    proxy_temp_file_write_size 64k;
+
     location / {
-        proxy_pass                 http://127.0.0.1:8000;
-        proxy_set_header           X-Real-IP   $remote_addr;
-        proxy_set_header           X-Forwarded-For  $proxy_add_x_forwarded_for;
-        proxy_set_header           X-Forwarded-Proto  $scheme;
-        proxy_set_header           X-Forwarded-Server  $host;
-        proxy_set_header           X-Forwarded-Host  $host;
-        proxy_set_header           Host  $host;
-
-        client_max_body_size       10m;
-        client_body_buffer_size    128k;
-
-        proxy_connect_timeout      90;
-        proxy_send_timeout         90;
-        proxy_read_timeout         90;
-
-        proxy_buffer_size          4k;
-        proxy_buffers              4 32k;
-        proxy_busy_buffers_size    64k;
-        proxy_temp_file_write_size 64k;
+        proxy_pass        http://127.0.0.1:8000;
+        proxy_set_header  Host                $host;
+        proxy_set_header  X-Real-IP           $remote_addr;
+        proxy_set_header  X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header  X-Forwarded-Proto   $scheme;
+        proxy_set_header  X-Forwarded-Server  $host;
+        proxy_set_header  X-Forwarded-Host    $host;
     }
 
     add_header Access-Control-Allow-Origin "*";

--- a/plugins/input-internal/Dockerfile
+++ b/plugins/input-internal/Dockerfile
@@ -1,4 +1,4 @@
-FROM juniper/pyez:2.0.1
+FROM juniper/pyez:2.1.8
 
 WORKDIR /source
 USER root
@@ -8,7 +8,7 @@ RUN apk add --no-cache ca-certificates && \
     update-ca-certificates
 RUN apk add --no-cache wget git
 
-ARG TELEGRAF_VERSION=1.2.1
+ARG TELEGRAF_VERSION=1.7.0
 
 #############################
 ## Install Telegraf

--- a/plugins/input-jti/fluent.conf
+++ b/plugins/input-jti/fluent.conf
@@ -33,7 +33,11 @@
 </source>
 <match juniperNetworks>
   @type rewrite_tag_filter
-  rewriterule1 sensor_name (.+)  ${tag}.$1
+  <rule>
+    key sensor_name
+    pattern /(.+)/
+    tag ${tag}.$1
+  </rule>
 </match>
 
 
@@ -44,7 +48,7 @@
 ##### CPU #######
 
 <match juniperNetworks.cpu_memory_util_ext>
-    type copy
+    @type copy
 {% if OUTPUT_STDOUT == 'true' %}
     <store>
         @type stdout
@@ -54,7 +58,7 @@
 {% endif %}
 {% if OUTPUT_INFLUXDB == 'true' %}
     <store>
-        type influxdb
+        @type influxdb
 
         host "{{ INFLUXDB_ADDR }}"
         port "{{ INFLUXDB_PORT }}"
@@ -104,7 +108,7 @@
 ############### PACKET STATS #############
 
 <match juniperNetworks.jnpr_packet_statistics_ext>
-    type copy
+    @type copy
 {% if OUTPUT_STDOUT == 'true' %}
     <store>
         @type stdout
@@ -114,7 +118,7 @@
 {% endif %}
 {% if OUTPUT_INFLUXDB == 'true' %}
     <store>
-        type influxdb
+        @type influxdb
         host "{{ INFLUXDB_ADDR }}"
         port "{{ INFLUXDB_PORT }}"
         dbname "{{ INFLUXDB_DB }}"
@@ -163,7 +167,7 @@
 ############### LSP STATS #################
 
 <match juniperNetworks.jnpr_lsp_statistics_ext>
-    type copy
+    @type copy
 {% if OUTPUT_STDOUT == 'true' %}
     <store>
         @type stdout
@@ -173,7 +177,7 @@
 {% endif %}
 {% if OUTPUT_INFLUXDB == 'true' %}
     <store>
-        type influxdb
+        @type influxdb
         host "{{ INFLUXDB_ADDR }}"
         port "{{ INFLUXDB_PORT }}"
         dbname "{{ INFLUXDB_DB }}"
@@ -222,7 +226,7 @@
 
 ################## ALL #############
 <match juniperNetworks.**>
-    type copy
+    @type copy
 {% if OUTPUT_STDOUT == 'true' %}
     <store>
         @type stdout
@@ -232,7 +236,7 @@
 {% endif %}
 {% if OUTPUT_INFLUXDB == 'true' %}
     <store>
-        type influxdb
+        @type influxdb
 
         host "{{ INFLUXDB_ADDR }}"
         port "{{ INFLUXDB_PORT }}"

--- a/plugins/input-snmp/Dockerfile
+++ b/plugins/input-snmp/Dockerfile
@@ -1,4 +1,4 @@
-FROM juniper/pyez:2.0.1
+FROM juniper/pyez:2.1.8
 
 WORKDIR /source
 USER root
@@ -8,7 +8,7 @@ RUN apk add --no-cache ca-certificates && \
     update-ca-certificates
 RUN apk add --no-cache wget git
 
-ARG TELEGRAF_VERSION=1.2.1
+ARG TELEGRAF_VERSION=1.7.0
 
 #############################
 ## Install Telegraf

--- a/plugins/input-snmp/templates/telegraf.tmpl
+++ b/plugins/input-snmp/templates/telegraf.tmpl
@@ -17,11 +17,11 @@
   timeout = "5s"
 
 [[inputs.snmp]]
-  agents = [ "172.30.137.90:161","172.30.137.93:161" ]
+  agents = [ "172.30.137.90:161", "172.30.137.93:161" ]
   version = 2
   community = "public"
-
   name = "system"
+
   [[inputs.snmp.field]]
     name = "hostname"
     oid = ".1.3.6.1.2.1.1.5.0"
@@ -32,11 +32,10 @@
   [[inputs.snmp.field]]
     name = "sysObjectID"
     oid = ".1.3.6.1.2.1.1.2.0"
+
   [[inputs.snmp.table]]
     name = "interface_statistics"
     inherit_tags = [ "hostname" ]
-    [inputs.snmp.tagpass]
-      ifName = ["[g|x]e-","ae"]
     [[inputs.snmp.table.field]]
       name = "ifName"
       oid = ".1.3.6.1.2.1.31.1.1.1.1"
@@ -58,11 +57,13 @@
       oid = ".1.3.6.1.2.1.31.1.1.1.9"
     [[inputs.snmp.table.field]]
       name = "ifHCOutBroadcastPkts"
-      oid = ".1.3.6.1.2.1.31.1.1.1.13"  
+      oid = ".1.3.6.1.2.1.31.1.1.1.13"
     [[inputs.snmp.table.field]]
       name = "ifHCOutUcastPkts"
       oid = ".1.3.6.1.2.1.31.1.1.1.11"
     [[inputs.snmp.table.field]]
       name = "ifHCInUcastPkts"
-      oid = ".1.3.6.1.2.1.31.1.1.1.7"  
+      oid = ".1.3.6.1.2.1.31.1.1.1.7"
 
+  [inputs.snmp.tagpass]
+    ifName = [ "[g|x]e-*", "ae*" ]

--- a/plugins/input-snmp/templates/telegraf.tmpl
+++ b/plugins/input-snmp/templates/telegraf.tmpl
@@ -41,6 +41,9 @@
       oid = ".1.3.6.1.2.1.31.1.1.1.1"
       is_tag = true
     [[inputs.snmp.table.field]]
+      name = "ifHighSpeed"
+      oid = ".1.3.6.1.2.1.31.1.1.1.15"
+    [[inputs.snmp.table.field]]
       name = "ifHCInOctets"
       oid = ".1.3.6.1.2.1.31.1.1.1.6"
     [[inputs.snmp.table.field]]

--- a/plugins/input-syslog/Dockerfile
+++ b/plugins/input-syslog/Dockerfile
@@ -1,7 +1,5 @@
-FROM fluent/fluentd:v0.12.29
+FROM fluent/fluentd:v0.12.43
 MAINTAINER Damien Garros <dgarros@gmail.com>
-
-ENV FLUENTD_JUNIPER_VERSION 0.2.11
 
 USER root
 WORKDIR /home/fluent
@@ -14,32 +12,27 @@ RUN apk update \
     && apk del -r --purge gcc make g++ \
     && rm -rf /var/cache/apk/*
 
-ENV PATH /home/fluent/.gem/ruby/2.2.0/bin:$PATH
-
-RUN apk --no-cache --update add \
-                            build-base \
-                            ruby-dev && \
-    echo 'gem: --no-document' >> /etc/gemrc && \
-    gem install --no-ri --no-rdoc \
-              yajl ltsv zookeeper \
-              influxdb \
-              bigdecimal && \
+RUN apk add --no-cache --virtual .build-deps \
+        build-base ruby-dev && \
+    gem install --no-ri \
+        yajl ltsv bigdecimal \
+        influxdb zookeeper && \
     gem install ruby-kafka -v 0.3.17 && \
-    apk del build-base ruby-dev && \
-    rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
+    apk del .build-deps && \
+    rm -rf /var/cache/apk/* && \
+    rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
 
 # Copy Start script to generate configuration dynamically
-ADD     fluentd-alpine.start.sh         fluentd-alpine.start.sh
-RUN     chown -R fluent:fluent fluentd-alpine.start.sh
-RUN     chmod 777 fluentd-alpine.start.sh
 
-COPY    fluent.conf /fluentd/etc/fluent.conf
-COPY    plugins /fluentd/plugins
+ADD   fluentd-alpine.start.sh  fluentd-alpine.start.sh
+RUN   chmod 777 fluentd-alpine.start.sh
 
-USER fluent
+COPY  fluent.conf /fluentd/etc/fluent.conf
+COPY  plugins /fluentd/plugins
 
-RUN   gem install --no-ri --no-rdoc fluent-plugin-newsyslog
-RUN   gem install --no-ri --no-rdoc fluent-plugin-rewrite-tag-filter -v 1.6.0
+RUN   gem install --no-ri fluent-plugin-newsyslog
+RUN   gem install --no-ri fluent-plugin-rewrite-tag-filter -v 1.6.0
+
 EXPOSE 24220
 
 ENV OUTPUT_KAFKA=false \

--- a/plugins/input-syslog/fluent.conf
+++ b/plugins/input-syslog/fluent.conf
@@ -1,6 +1,3 @@
-# In v1 configuration, type and id are @ prefix parameters.
-# @type and @id are recommended. type and id are still available for backward compatibility
-
 ## built-in TCP input
 ## $ echo <json> | fluent-cat <tag>
 
@@ -14,7 +11,7 @@
 #################
 
 <source>
-    type syslog
+    @type syslog
     format newsyslog
     port "{{PORT_SYSLOG}}"
     bind 0.0.0.0
@@ -49,7 +46,11 @@
 ## Rewrite syslog tag to remove severity and facility
 <match jnpr_events.**>
   @type rewrite_tag_filter
-  rewriterule1 message .*  events
+  <rule>
+    key message
+    pattern /.*/
+    tag events
+  </rule>
 </match>
 
 #################
@@ -57,7 +58,7 @@
 #################
 
 <match events.**>
-    type copy
+    @type copy
 {% if OUTPUT_STDOUT == 'true' %}
     <store>
         @type stdout
@@ -66,7 +67,7 @@
 {% endif %}
 {% if OUTPUT_INFLUXDB == 'true' %}
     <store>
-        type influxdb
+        @type influxdb
         host "{{ INFLUXDB_ADDR }}"
         port "{{ INFLUXDB_PORT }}"
         dbname "{{ INFLUXDB_DB }}"
@@ -86,7 +87,7 @@
 {% endif %}
 {% if OUTPUT_MQTT == 'true' %}
     <store>
-        type mqtt
+        @type mqtt
         topic juniper
 
         ####
@@ -123,14 +124,14 @@
 </match>
 
 # <match monitor.**>
-#     type copy
+#     @type copy
 #     <store>
 #         @type stdout
 #         @id stdout_output
 #     </store>
 # {% if OUTPUT_INFLUXDB == 'true' %}
 #     <store>
-#         type influxdb
+#         @type influxdb
 #         host "{{ INFLUXDB_ADDR }}"
 #         port "{{ INFLUXDB_PORT }}"
 #         dbname "{{ INFLUXDB_DB }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest
-influxdb==2.11.0
+influxdb
 pytest-cov
 docker-py
 requests


### PR DESCRIPTION
* Grafana up to `v5.2.0`.
* InfluxData/InfluxDB up to `v1.5.4`.
* InfluxData/Telegraf up to `v1.7.0-1`.
* input-syslog `rewrite_tag_filter`: Migration deprecated `rewriterule*` to `rule`.
* input-syslog `rewrite_tag_filter`: Migrate all deprecated `type` to `@type`.
* input-snmp: Bugfix syntax error in the file parsing telegraf.conf, recent versions of Telegraf could have refused to read the snmp section.