### PR TITLE
Fiex the bug from parse_result re.search function

### DIFF
--- a/open-nti/open-nti.py
+++ b/open-nti/open-nti.py
@@ -362,7 +362,7 @@ def parse_result(host,target_command,result,datapoints,kpi_tags):
     parser_found = False
     for junos_parser in junos_parsers:
         regex_command = junos_parser["parser"]["regex-command"]
-        if re.search(regex_command, target_command, re.IGNORECASE):
+        if re.search(regex_command + "$", target_command, re.IGNORECASE):
             parser_found = True
             matches = junos_parser["parser"]["matches"]
             timestamp = str(int(datetime.today().strftime('%s')))


### PR DESCRIPTION
this modification fixes the bug of the selection the wrong **regex_command** from the **_parser.yaml_** file and searching it in the **target_command** string from the **_hosts.yaml_** file: for example if during one iteration over all the parser files we have the **regex_command**="show\s+interfaces\s+TenGigE0/2/0/2" and the **target_command**="show interfaces TenGigE0/2/0/22" then the **_if re.search(regex_command, target_command, re.IGNORECASE)_** check from the _parse_result_ function from _open-nti.py_ script will return **True** but we need it to return **False**. For accomplishing this but we only need to add the terminating sign **_$_** to the **regex_command** string so that it search and match the exact **target_command**.